### PR TITLE
Add method to rescue from post response thats not parsable JSON

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in pusher-push_notifications.gemspec
 gemspec
+
+gem 'codecov', :require => false, :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pusher-push-notifications (0.3.0)
+    pusher-push-notifications (0.3.1)
       caze
       rest-client
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,10 @@ GEM
     byebug (9.1.0)
     caze (0.2.2)
       activesupport (>= 3)
+    codecov (0.1.10)
+      json
+      simplecov
+      url
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     coveralls (0.8.21)
@@ -101,6 +105,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.3.0)
+    url (0.3.2)
     vcr (3.0.3)
     webmock (3.1.1)
       addressable (>= 2.3.6)
@@ -112,6 +117,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  codecov
   coveralls (~> 0.8.21)
   dotenv (~> 2.2, >= 2.2.1)
   pry-byebug

--- a/lib/pusher/push_notifications/client.rb
+++ b/lib/pusher/push_notifications/client.rb
@@ -56,7 +56,7 @@ module Pusher
         JSON.parse(response)
         true
       rescue JSON::ParserError
-        return false
+        false
       end
     end
   end

--- a/lib/pusher/push_notifications/client.rb
+++ b/lib/pusher/push_notifications/client.rb
@@ -26,8 +26,12 @@ module Pusher
           payload: body, headers: headers
         ) do |response|
           status = response.code
-          body = parse_response(response.body)
-          Response.new(status, body, status == 200 ? true : false)
+          if json?(response.body)
+            body = JSON.parse(response.body)
+            Response.new(status, body, status == 200)
+          else
+            Response.new('Internal server error', nil, false)
+          end
         end
       end
 
@@ -48,10 +52,11 @@ module Pusher
         }
       end
 
-      def parse_response(response)
+      def json?(response)
         JSON.parse(response)
-      rescue JSON::ParserError => e
-        ""
+        true
+      rescue JSON::ParserError
+        return false
       end
     end
   end

--- a/lib/pusher/push_notifications/client.rb
+++ b/lib/pusher/push_notifications/client.rb
@@ -30,7 +30,7 @@ module Pusher
             body = JSON.parse(response.body)
             Response.new(status, body, status == 200)
           else
-            Response.new('Internal server error', nil, false)
+            Response.new(500, nil, false)
           end
         end
       end

--- a/lib/pusher/push_notifications/client.rb
+++ b/lib/pusher/push_notifications/client.rb
@@ -26,7 +26,7 @@ module Pusher
           payload: body, headers: headers
         ) do |response|
           status = response.code
-          body = JSON.parse(response.body)
+          body = parse_response(response.body)
           Response.new(status, body, status == 200 ? true : false)
         end
       end
@@ -46,6 +46,12 @@ module Pusher
           accept: :json,
           Authorization: "Bearer #{secret_key}"
         }
+      end
+
+      def parse_response(response)
+        JSON.parse(response)
+      rescue JSON::ParserError => e
+        ""
       end
     end
   end

--- a/lib/pusher/push_notifications/version.rb
+++ b/lib/pusher/push_notifications/version.rb
@@ -2,6 +2,6 @@
 
 module Pusher
   module PushNotifications
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,12 @@ require 'pusher-push-notifications'
 require 'vcr'
 require 'webmock'
 
+require 'simplecov'
+SimpleCov.start
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock


### PR DESCRIPTION
When attempting to publish a message if herokucdn has an application error, it returns HTML error page in response body instead of JSON that throws a `JSON::ParserError` exception. This pull request adds a parse_response method that will rescue from this error and set body to an empty string if it does get HTML response. 

Here is the error that happens that this would rescue from after calling `Pusher::PushNotifications.publish`:
```
JSON::ParserError: 765: unexpected token at '<!DOCTYPE html> <html> <head> <meta name="viewport" content="width=device-width, initial-scale=1"> <meta charset="utf-8"> <title>Application Error</title> <style media="screen"> html,body,iframe { margin: 0; padding: 0; } html,body { height: 100%; overflow: hidden; } iframe { width: 100%; height: 100%; border: 0; } </style> </head> <body> <iframe src="//www.herokucdn.com/error-pages/application-error.html"></iframe> </body> </html>'
```