### PR TITLE
Set rubocop to version 0.49.0 or later

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ DEPENDENCIES
   rake (~> 10.0)
   rb-readline (~> 0)
   rspec (~> 3.0)
-  rubocop (~> 0)
+  rubocop (>= 0.49.0)
   vcr (~> 3.0, >= 3.0.3)
   webmock (~> 3.0, >= 3.0.1)
 

--- a/pusher-push-notifications.gemspec
+++ b/pusher-push-notifications.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rb-readline', '~> 0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0'
+  spec.add_development_dependency 'rubocop', '>= 0.49.0'
   spec.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.3'
   spec.add_development_dependency 'webmock', '~> 3.0', '>= 3.0.1'
 end


### PR DESCRIPTION
Fix for [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2017-8418) that can be found in RuboCop 0.48.1 and earlier.