### PR TITLE
Endpoint using http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/push-notifications-ruby/compare/v1.2.0...HEAD)
+## [Unreleased](https://github.com/pusher/push-notifications-ruby/compare/v1.2.1...HEAD)
+
+## [1.2.1](https://github.com/pusher/push-notifications-ruby/compare/v1.2.0...v1.2.1) - 2020-06-26
+
+Fixed
+
+Endpoint also allows the scheme to be configured to enable for local development.
 
 ## [1.2.0](https://github.com/pusher/push-notifications-ruby/compare/v1.1.0...v1.2.0) - 2020-06-25
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pusher-push-notifications (1.2.0)
+    pusher-push-notifications (1.2.1)
       caze (~> 0)
       jwt (~> 2.1, >= 2.1.0)
       rest-client (~> 2.0, >= 2.0.2)

--- a/lib/pusher/push_notifications.rb
+++ b/lib/pusher/push_notifications.rb
@@ -56,7 +56,7 @@ module Pusher
       def endpoint
         return @endpoint unless @endpoint.nil?
 
-        "#{@instance_id}.pushnotifications.pusher.com"
+        "https://#{@instance_id}.pushnotifications.pusher.com"
       end
     end
   end

--- a/lib/pusher/push_notifications/client.rb
+++ b/lib/pusher/push_notifications/client.rb
@@ -57,13 +57,11 @@ module Pusher
       def_delegators :@config, :instance_id, :secret_key, :endpoint
 
       def build_publish_url(resource)
-        "https://#{endpoint}/" \
-        "publish_api/v1/instances/#{instance_id}/#{resource}"
+        "#{endpoint}/publish_api/v1/instances/#{instance_id}/#{resource}"
       end
 
       def build_users_url(user)
-        "https://#{endpoint}/" \
-        "customer_api/v1/instances/#{instance_id}/users/#{user}"
+        "#{endpoint}/customer_api/v1/instances/#{instance_id}/users/#{user}"
       end
 
       def headers

--- a/lib/pusher/push_notifications/version.rb
+++ b/lib/pusher/push_notifications/version.rb
@@ -2,6 +2,6 @@
 
 module Pusher
   module PushNotifications
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end

--- a/spec/pusher/push_notifications/client_spec.rb
+++ b/spec/pusher/push_notifications/client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Pusher::PushNotifications::Client do
       :config,
       instance_id: instance_id,
       secret_key: secret_key,
-      endpoint: "#{instance_id}.pushnotifications.pusher.com"
+      endpoint: "https://#{instance_id}.pushnotifications.pusher.com"
     )
   end
 

--- a/spec/pusher/push_notifications/configuration_spec.rb
+++ b/spec/pusher/push_notifications/configuration_spec.rb
@@ -73,12 +73,12 @@ RSpec.describe Pusher::PushNotifications do
     end
 
     context 'when endpoint is valid' do
-      let(:endpoint) { 'testcluster.pusher.com' }
+      let(:endpoint) { 'https://testcluster.pusher.com' }
 
       it 'overrides the default endpoint' do
         configuration
 
-        expect(configuration.endpoint).to eq('testcluster.pusher.com')
+        expect(configuration.endpoint).to eq('https://testcluster.pusher.com')
       end
     end
 
@@ -95,7 +95,7 @@ RSpec.describe Pusher::PushNotifications do
         expect(configuration.endpoint).not_to be_nil
         expect(configuration.endpoint).not_to be_empty
         expect(configuration.endpoint).to eq(
-          "#{configuration.instance_id}.pushnotifications.pusher.com"
+          "https://#{configuration.instance_id}.pushnotifications.pusher.com"
         )
       end
     end


### PR DESCRIPTION
This makes it consistent with https://github.com/pusher/push-notifications-node/blob/dca3bb891b5cd7ee13001a1e639e2c14e4cf57de/push-notifications.js#L39-L42, even though I'd maybe opt for a "base url override" that included the scheme.