### PR TITLE
Allow multiple instances to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/push-notifications-ruby/compare/v1.2.1...HEAD)
+## [Unreleased](https://github.com/pusher/push-notifications-ruby/compare/v1.3.0...HEAD)
+
+## [1.3.0](https://github.com/pusher/push-notifications-ruby/compare/v1.2.1...v1.3.0) - 2020-07-01
+
+Added
+
+Support for multiple instances of Beams clients to exist for more advanced use cases.
 
 ## [1.2.1](https://github.com/pusher/push-notifications-ruby/compare/v1.2.0...v1.2.1) - 2020-06-26
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pusher-push-notifications (1.2.1)
+    pusher-push-notifications (1.3.0)
       caze (~> 0)
       jwt (~> 2.1, >= 2.1.0)
       rest-client (~> 2.0, >= 2.0.2)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Pusher::PushNotifications.configure do |config|
 end
 ```
 
-Where `instance_id` and `secret_key` are the values of the instance you created in the Pusher Beams dashboard
+Where `instance_id` and `secret_key` are the values of the instance you created in the Pusher Beams dashboard.
+
+If multiple clients are needed, store the reference that is returned from the `configure` method.
 
 ## Usage
 

--- a/lib/pusher/push_notifications.rb
+++ b/lib/pusher/push_notifications.rb
@@ -28,7 +28,9 @@ module Pusher
 
       def configure
         yield(self)
-        self
+        # returning a duplicate of `self` to allow multiple clients to be
+        # configured without needing to reconfigure the singleton instance
+        dup
       end
 
       def instance_id=(instance_id)

--- a/lib/pusher/push_notifications/version.rb
+++ b/lib/pusher/push_notifications/version.rb
@@ -2,6 +2,6 @@
 
 module Pusher
   module PushNotifications
-    VERSION = '1.2.1'
+    VERSION = '1.3.0'
   end
 end

--- a/spec/pusher/push_notifications/configuration_spec.rb
+++ b/spec/pusher/push_notifications/configuration_spec.rb
@@ -99,5 +99,25 @@ RSpec.describe Pusher::PushNotifications do
         )
       end
     end
+
+    context 'when multiple instances are needed' do
+      it 'returns unique clients' do
+        client1 = described_class.configure do |config|
+          config.instance_id = 'acd22e93-d8d6-43ba-9023-20ec05b1d08e'
+          config.secret_key = '123'
+          config.endpoint = 'https://testcluster.pusher.com'
+        end
+        client2 = described_class.configure do |config|
+          config.instance_id = instance_id
+          config.secret_key = secret_key
+          config.endpoint = endpoint
+        end
+
+        expect(client1).not_to eq(client2)
+        expect(client1.instance_id).not_to eq(client2.instance_id)
+        expect(client1.secret_key).not_to eq(client2.secret_key)
+        expect(client1.endpoint).not_to eq(client2.endpoint)
+      end
+    end
   end
 end


### PR DESCRIPTION
This can be useful to support whitelabeling use case or our dashboard making requests on behalf of different instances.