### PR TITLE
Fix Gemfile.lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,12 @@ jobs:
       - name: Prepare version.rb
         run: |
           sed -i "s|VERSION = '[^']*'|VERSION = '${{ env.VERSION }}'|" lib/pusher/push_notifications/version.rb
+      - name: Prepare Gemfile.lock
+        run: |
+          sed -i "s|pusher-push-notifications ([^)]*)|pusher-push-notifications (${{ env.VERSION }})|" Gemfile.lock
       - name: Commit changes
         run: |
-          git add CHANGELOG.md lib/pusher/push_notifications/version.rb
+          git add CHANGELOG.md lib/pusher/push_notifications/version.rb Gemfile.lock
           git commit -m "Bump to version ${{ env.VERSION }}"
       - name: Push
         run: git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+* [CHANGED] Update Gemfile lock on release.
+
 ## 2.0.0
 
 * [ADDED] Support for Ruby 3.0.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pusher-push-notifications (1.3.0)
+    pusher-push-notifications (2.0.1)
       jwt (~> 2.1, >= 2.1.0)
       rest-client (~> 2.0, >= 2.0.2)
 

--- a/lib/pusher/push_notifications/version.rb
+++ b/lib/pusher/push_notifications/version.rb
@@ -2,6 +2,6 @@
 
 module Pusher
   module PushNotifications
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end


### PR DESCRIPTION
## Description

The lock file needs to be updated when the lib version is bumped, otherwise bundle install fails later. We could also let bundle handle it, but this works well (and is simpler atm).

## CHANGELOG

* [CHANGED] Update Gemfile lock on release.
