### PR TITLE
Simplify UseCases implementation and fix issue with multiple configurations

### DIFF
--- a/lib/pusher/push_notifications.rb
+++ b/lib/pusher/push_notifications.rb
@@ -14,14 +14,7 @@ module Pusher
     class PushError < RuntimeError; end
 
     class << self
-      extend Forwardable
-
       attr_reader :instance_id, :secret_key
-
-      def_delegators UseCases::Publish, :publish, :publish_to_interests
-      def_delegators UseCases::PublishToUsers, :publish_to_users
-      def_delegators UseCases::DeleteUser, :delete_user
-      def_delegators UseCases::GenerateToken, :generate_token
 
       def configure
         yield(self)
@@ -52,6 +45,32 @@ module Pusher
         return @endpoint unless @endpoint.nil?
 
         "https://#{@instance_id}.pushnotifications.pusher.com"
+      end
+
+      def publish(interests:, payload: {})
+        UseCases::Publish.publish(client, interests: interests, payload: payload)
+      end
+
+      def publish_to_interests(interests:, payload: {})
+        UseCases::Publish.publish_to_interests(client, interests: interests, payload: payload)
+      end
+
+      def publish_to_users(users:, payload: {})
+        UseCases::PublishToUsers.publish_to_users(client, users: users, payload: payload)
+      end
+
+      def delete_user(user:)
+        UseCases::DeleteUser.delete_user(client, user: user)
+      end
+
+      def generate_token(user:)
+        UseCases::GenerateToken.generate_token(user: user)
+      end
+
+      private
+
+      def client
+        @client ||= Client.new(config: self)
       end
     end
   end

--- a/lib/pusher/push_notifications/use_cases/delete_user.rb
+++ b/lib/pusher/push_notifications/use_cases/delete_user.rb
@@ -6,36 +6,17 @@ module Pusher
       class DeleteUser
         class UserDeletionError < RuntimeError; end
 
-        class << self
-          def delete_user(*args, **kwargs)
-            new(*args, **kwargs).delete_user
-          end
-        end
-
-        def initialize(user:)
-          @user = user
-          @user_id = Pusher::PushNotifications::UserId.new
-
+        # Contacts the Beams service
+        # to remove all the devices of the given user.
+        def self.delete_user(client, user:)
           raise UserDeletionError, 'User Id cannot be empty.' if user.empty?
 
           if user.length > UserId::MAX_USER_ID_LENGTH
             raise UserDeletionError, 'User id length too long ' \
             "(expected fewer than #{UserId::MAX_USER_ID_LENGTH + 1} characters)"
           end
-        end
 
-        # Contacts the Beams service
-        # to remove all the devices of the given user.
-        def delete_user
           client.delete(user)
-        end
-
-        private
-
-        attr_reader :user
-
-        def client
-          @client ||= PushNotifications::Client.new
         end
       end
     end

--- a/lib/pusher/push_notifications/use_cases/generate_token.rb
+++ b/lib/pusher/push_notifications/use_cases/generate_token.rb
@@ -6,35 +6,18 @@ module Pusher
       class GenerateToken
         class GenerateTokenError < RuntimeError; end
 
-        class << self
-          def generate_token(*args, **kwargs)
-            new(*args, **kwargs).generate_token
-          end
-        end
-
-        def initialize(user:)
-          @user = user
-          @user_id = Pusher::PushNotifications::UserId.new
-
+        # Creates a signed JWT for a user id.
+        def self.generate_token(user:)
           raise GenerateTokenError, 'User Id cannot be empty.' if user.empty?
 
           if user.length > UserId::MAX_USER_ID_LENGTH
             raise GenerateTokenError, 'User id length too long ' \
             "(expected fewer than #{UserId::MAX_USER_ID_LENGTH + 1} characters)"
           end
-        end
 
-        # Creates a signed JWT for a user id.
-        def generate_token
+          jwt_token = PushNotifications::Token.new
+
           { 'token' => jwt_token.generate(user) }
-        end
-
-        private
-
-        attr_reader :user
-
-        def jwt_token
-          @jwt_token ||= PushNotifications::Token.new
         end
       end
     end

--- a/lib/pusher/push_notifications/use_cases/publish.rb
+++ b/lib/pusher/push_notifications/use_cases/publish.rb
@@ -6,21 +6,16 @@ module Pusher
       class Publish
         class PublishError < RuntimeError; end
 
-        class << self
-          def publish(*args, **kwargs)
-            new(*args, **kwargs).publish
-          end
-
-          def publish_to_interests(*args, **kwargs)
-            new(*args, **kwargs).publish_to_interests
-          end
+        # Publish the given payload to the specified interests.
+        # <b>DEPRECATED:</b> Please use <tt>publish_to_interests</tt> instead.
+        def self.publish(client, interests:, payload: {})
+          warn "[DEPRECATION] `publish` is deprecated. \
+Please use `publish_to_interests` instead."
+          publish_to_interests(client, interests: interests, payload: payload)
         end
 
-        def initialize(interests:, payload: {})
-          @interests = interests
-          @payload = payload
-          @user_id = Pusher::PushNotifications::UserId.new
-
+        # Publish the given payload to the specified interests.
+        def self.publish_to_interests(client, interests:, payload: {})
           valid_interest_pattern = /^(_|-|=|@|,|\.|:|[A-Z]|[a-z]|[0-9])*$/
 
           interests.each do |interest|
@@ -38,28 +33,9 @@ module Pusher
             raise PublishError, "Number of interests #{interests.length}" \
             ' exceeds maximum of 100'
           end
-        end
 
-        # Publish the given payload to the specified interests.
-        # <b>DEPRECATED:</b> Please use <tt>publish_to_interests</tt> instead.
-        def publish
-          warn "[DEPRECATION] `publish` is deprecated. \
-Please use `publish_to_interests` instead."
-          publish_to_interests
-        end
-
-        # Publish the given payload to the specified interests.
-        def publish_to_interests
           data = { interests: interests }.merge!(payload)
           client.post('publishes', data)
-        end
-
-        private
-
-        attr_reader :interests, :payload
-
-        def client
-          @client ||= PushNotifications::Client.new
         end
       end
     end

--- a/lib/pusher/push_notifications/use_cases/publish_to_users.rb
+++ b/lib/pusher/push_notifications/use_cases/publish_to_users.rb
@@ -6,17 +6,8 @@ module Pusher
       class PublishToUsers
         class UsersPublishError < RuntimeError; end
 
-        class << self
-          def publish_to_users(*args, **kwargs)
-            new(*args, **kwargs).publish_to_users
-          end
-        end
-
-        def initialize(users:, payload: {})
-          @users = users
-          @user_id = Pusher::PushNotifications::UserId.new
-          @payload = payload
-
+        # Publish the given payload to the specified users.
+        def self.publish_to_users(client, users:, payload: {})
           users.each do |user|
             raise UsersPublishError, 'User Id cannot be empty.' if user.empty?
 
@@ -33,20 +24,9 @@ module Pusher
             raise UsersPublishError, "Number of user ids #{users.length} "\
             "exceeds maximum of #{UserId::MAX_NUM_USER_IDS}."
           end
-        end
 
-        # Publish the given payload to the specified users.
-        def publish_to_users
           data = { users: users }.merge!(payload)
           client.post('publishes/users', data)
-        end
-
-        private
-
-        attr_reader :users, :payload
-
-        def client
-          @client ||= PushNotifications::Client.new
         end
       end
     end


### PR DESCRIPTION
## Description

Simplify internal implementation. The functionality of the library is split into multiple classes in the `UseCases` module. Functions in those classes were called by the main `PushNotification` class through delegation. This PR simplifies the code by using plain functions and calling them in the `PushNotification` class. This leads to less code, less indirection and less allocation. It also makes it easier to pass parameters from `PushNotification` to the `UseCases` functions, such as the correct client, which fixes the issue with multiple instances where the global client would still be used.

Fixes #28.

## CHANGELOG

* [FIXED] Correct client is used when making requests with multiple instances
